### PR TITLE
 fix(offres-emploi): fix du champ query pas utilisé

### DIFF
--- a/src/infrastructure/routes/offres-emploi.controller.ts
+++ b/src/infrastructure/routes/offres-emploi.controller.ts
@@ -33,6 +33,7 @@ export class OffresEmploiController {
     const query: GetOffresEmploiQuery = {
       page: findOffresEmploiPayload.page,
       limit: findOffresEmploiPayload.limit,
+      query: findOffresEmploiPayload.q,
       departement: findOffresEmploiPayload.departement,
       alternance: findOffresEmploiPayload.alternance === 'true'
     }


### PR DESCRIPTION
J'ai remarqué pendant mes tests que le filtre sur le métier ne fonctionnait pas, le paramètre query n'était pas passé à PE.