### PR TITLE
feat(session): 178 - JEUNE voit la liste des sessions de sa structure que le conseiller lui a rendu visible

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -296,8 +296,8 @@ import { SuivreEvenementsMiloCronJobHandler } from './application/cron-jobs/suiv
 import { MiloRendezVousHttpRepository } from './infrastructure/repositories/rendez-vous/rendez-vous-milo-http.repository'
 import { TraiterEvenementMiloJobHandler } from './application/jobs/traiter-evenement-milo.handler'
 import {
-  RendezVousMilo,
-  MiloRendezVousRepositoryToken
+  MiloRendezVousRepositoryToken,
+  RendezVousMilo
 } from './domain/rendez-vous/rendez-vous.milo'
 import { MiloJeuneRepositoryToken } from './domain/milo/jeune.milo'
 import { HandleJobFakeCommandHandler } from './application/commands/jobs/handle-job-fake.command'
@@ -323,7 +323,7 @@ import { GetCVPoleEmploiQueryHandler } from './application/queries/get-cv-pole-e
 import { EvenementsEmploiController } from './infrastructure/routes/evenements-emploi.controller'
 import { GetEvenementsEmploiQueryHandler } from './application/queries/get-evenements-emploi.query.handler'
 import { GetEvenementEmploiQueryHandler } from './application/queries/get-evenement-emploi.query.handler'
-import { GetSessionsMiloQueryHandler } from './application/queries/milo/get-sessions.milo.query.handler.db'
+import { GetSessionsConseillerMiloQueryHandler } from 'src/application/queries/milo/get-sessions-conseiller.milo.query.handler.db'
 import { MiloClient } from './infrastructure/clients/milo-client'
 import { ConseillerMiloRepositoryToken } from './domain/milo/conseiller.milo'
 import { ConseillerMiloSqlRepository } from './infrastructure/repositories/milo/conseiller.milo.repository.db'
@@ -337,6 +337,7 @@ import {
   SessionMiloRepositoryToken
 } from './domain/milo/session.milo'
 import { SessionMiloSqlRepository } from './infrastructure/repositories/milo/session.milo.repository.db'
+import { GetSessionsJeuneMiloQueryHandler } from 'src/application/queries/milo/get-sessions-jeune.milo.query.handler.db'
 
 export const buildModuleMetadata = (): ModuleMetadata => ({
   imports: [
@@ -737,7 +738,8 @@ export function buildQueryCommandsProviders(): Provider[] {
     GetCVPoleEmploiQueryHandler,
     GetEvenementsEmploiQueryHandler,
     GetEvenementEmploiQueryHandler,
-    GetSessionsMiloQueryHandler,
+    GetSessionsConseillerMiloQueryHandler,
+    GetSessionsJeuneMiloQueryHandler,
     GetDetailSessionMiloQueryHandler,
     UpdateSessionMiloCommandHandler,
     EvenementEmploiCodePostalQueryGetter,

--- a/src/application/queries/milo/get-sessions-conseiller.milo.query.handler.db.ts
+++ b/src/application/queries/milo/get-sessions-conseiller.milo.query.handler.db.ts
@@ -1,24 +1,20 @@
 import { Inject, Injectable } from '@nestjs/common'
 import { DateTime } from 'luxon'
-import { Query } from '../../../building-blocks/types/query'
-import { QueryHandler } from '../../../building-blocks/types/query-handler'
-import {
-  Result,
-  isFailure,
-  success
-} from '../../../building-blocks/types/result'
-import { Authentification } from '../../../domain/authentification'
-import { Conseiller } from '../../../domain/conseiller/conseiller'
-import { estMilo } from '../../../domain/core'
-import { ConseillerMiloRepositoryToken } from '../../../domain/milo/conseiller.milo'
-import { KeycloakClient } from '../../../infrastructure/clients/keycloak-client'
-import { MiloClient } from '../../../infrastructure/clients/milo-client'
+import { Query } from 'src/building-blocks/types/query'
+import { QueryHandler } from 'src/building-blocks/types/query-handler'
+import { isFailure, Result, success } from 'src/building-blocks/types/result'
+import { Authentification } from 'src/domain/authentification'
+import { Conseiller } from 'src/domain/conseiller/conseiller'
+import { estMilo } from 'src/domain/core'
+import { ConseillerMiloRepositoryToken } from 'src/domain/milo/conseiller.milo'
+import { KeycloakClient } from 'src/infrastructure/clients/keycloak-client'
+import { MiloClient } from 'src/infrastructure/clients/milo-client'
 import { ConseillerAuthorizer } from '../../authorizers/conseiller-authorizer'
-import { mapSessionDtoToQueryModel } from '../query-mappers/milo.mappers'
+import { mapSessionConseillerDtoToQueryModel } from '../query-mappers/milo.mappers'
 import { SessionConseillerMiloQueryModel } from '../query-models/sessions.milo.query.model'
 import { SessionMiloSqlModel } from 'src/infrastructure/sequelize/models/session-milo.sql-model'
 
-export interface GetSessionsMiloQuery extends Query {
+export interface GetSessionsConseillerMiloQuery extends Query {
   idConseiller: string
   token: string
   dateDebut?: DateTime
@@ -26,8 +22,8 @@ export interface GetSessionsMiloQuery extends Query {
 }
 
 @Injectable()
-export class GetSessionsMiloQueryHandler extends QueryHandler<
-  GetSessionsMiloQuery,
+export class GetSessionsConseillerMiloQueryHandler extends QueryHandler<
+  GetSessionsConseillerMiloQuery,
   Result<SessionConseillerMiloQueryModel[]>
 > {
   constructor(
@@ -37,11 +33,11 @@ export class GetSessionsMiloQueryHandler extends QueryHandler<
     private conseillerAuthorizer: ConseillerAuthorizer,
     private keycloakClient: KeycloakClient
   ) {
-    super('GetSessionsMiloQueryHandler')
+    super('GetSessionsConseillerMiloQueryHandler')
   }
 
   async handle(
-    query: GetSessionsMiloQuery
+    query: GetSessionsConseillerMiloQuery
   ): Promise<Result<SessionConseillerMiloQueryModel[]>> {
     const resultConseiller = await this.conseillerMiloRepository.get(
       query.idConseiller
@@ -75,7 +71,7 @@ export class GetSessionsMiloQueryHandler extends QueryHandler<
         const sessionSqlModel = sessionsSqlModels.find(
           ({ id }) => id === sessionMilo.session.id.toString()
         )
-        return mapSessionDtoToQueryModel(
+        return mapSessionConseillerDtoToQueryModel(
           sessionMilo,
           sessionSqlModel?.estVisible ?? false,
           timezoneStructure
@@ -86,7 +82,7 @@ export class GetSessionsMiloQueryHandler extends QueryHandler<
   }
 
   async authorize(
-    query: GetSessionsMiloQuery,
+    query: GetSessionsConseillerMiloQuery,
     utilisateur: Authentification.Utilisateur
   ): Promise<Result> {
     return this.conseillerAuthorizer.autoriserLeConseiller(

--- a/src/application/queries/milo/get-sessions-jeune.milo.query.handler.db.ts
+++ b/src/application/queries/milo/get-sessions-jeune.milo.query.handler.db.ts
@@ -1,0 +1,126 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { Query } from 'src/building-blocks/types/query'
+import { QueryHandler } from 'src/building-blocks/types/query-handler'
+import {
+  failure,
+  isFailure,
+  Result,
+  success
+} from 'src/building-blocks/types/result'
+import { Authentification } from 'src/domain/authentification'
+import { SessionJeuneMiloQueryModel } from 'src/application/queries/query-models/sessions.milo.query.model'
+import { estMilo } from 'src/domain/core'
+import { JeuneAuthorizer } from 'src/application/authorizers/jeune-authorizer'
+import { Jeune, JeunesRepositoryToken } from 'src/domain/jeune/jeune'
+import {
+  JeuneMiloSansIdDossier,
+  NonTrouveError
+} from 'src/building-blocks/types/domain-error'
+import { KeycloakClient } from 'src/infrastructure/clients/keycloak-client'
+import { MiloClient } from 'src/infrastructure/clients/milo-client'
+import { mapSessionJeuneDtoToQueryModel } from 'src/application/queries/query-mappers/milo.mappers'
+import { SessionMiloSqlModel } from 'src/infrastructure/sequelize/models/session-milo.sql-model'
+import { StructureMiloSqlModel } from 'src/infrastructure/sequelize/models/structure-milo.sql-model'
+import { SessionJeuneDetailDto } from 'src/infrastructure/clients/dto/milo.dto'
+
+export interface GetSessionsJeuneMiloQuery extends Query {
+  idJeune: string
+  token: string
+}
+
+@Injectable()
+export class GetSessionsJeuneMiloQueryHandler extends QueryHandler<
+  GetSessionsJeuneMiloQuery,
+  Result<SessionJeuneMiloQueryModel[]>
+> {
+  constructor(
+    @Inject(JeunesRepositoryToken)
+    private readonly jeuneRepository: Jeune.Repository,
+    private readonly keycloakClient: KeycloakClient,
+    private readonly miloClient: MiloClient,
+    private readonly jeuneAuthorizer: JeuneAuthorizer
+  ) {
+    super('GetSessionsJeuneMiloQueryHandler')
+  }
+
+  async handle(
+    query: GetSessionsJeuneMiloQuery
+  ): Promise<Result<SessionJeuneMiloQueryModel[]>> {
+    const jeune = await this.jeuneRepository.get(query.idJeune)
+    if (!jeune) {
+      return failure(new NonTrouveError('Jeune', query.idJeune))
+    }
+    if (!jeune.idPartenaire) {
+      return failure(new JeuneMiloSansIdDossier(query.idJeune))
+    }
+
+    const idpToken = await this.keycloakClient.exchangeTokenJeune(
+      query.token,
+      jeune.structure
+    )
+
+    const resultSessionMiloClient = await this.miloClient.getSessionsJeune(
+      idpToken,
+      jeune.idPartenaire
+    )
+
+    if (isFailure(resultSessionMiloClient)) {
+      return resultSessionMiloClient
+    }
+
+    const sessionsVisiblesQueryModels = await recupererTimezoneSessionsVisibles(
+      resultSessionMiloClient.data.sessions
+    )
+    return success(sessionsVisiblesQueryModels)
+  }
+
+  async authorize(
+    query: GetSessionsJeuneMiloQuery,
+    utilisateur: Authentification.Utilisateur
+  ): Promise<Result> {
+    return this.jeuneAuthorizer.autoriserLeJeune(
+      query.idJeune,
+      utilisateur,
+      estMilo(utilisateur.structure)
+    )
+  }
+
+  async monitor(): Promise<void> {
+    return
+  }
+}
+async function recupererTimezoneSessionsVisibles(
+  sessionsMilo: SessionJeuneDetailDto[]
+): Promise<SessionJeuneMiloQueryModel[]> {
+  const mapSessionsVisiblesTimezone = await mapperSessionsVisiblesToTimezone(
+    sessionsMilo
+  )
+
+  return sessionsMilo
+    .filter(({ session: { id } }) =>
+      mapSessionsVisiblesTimezone.has(id.toString())
+    )
+    .map(session =>
+      mapSessionJeuneDtoToQueryModel(
+        session,
+        mapSessionsVisiblesTimezone.get(session.session.id.toString())!
+      )
+    )
+}
+
+async function mapperSessionsVisiblesToTimezone(
+  sessionsMiloClient: SessionJeuneDetailDto[]
+): Promise<Map<string, string>> {
+  const sessionsVisibles = await SessionMiloSqlModel.findAll({
+    where: {
+      id: sessionsMiloClient.map(session => session.session.id.toString()),
+      estVisible: true
+    },
+    include: [{ model: StructureMiloSqlModel, as: 'structure' }]
+  })
+
+  return sessionsVisibles.reduce((map, sessionVisible) => {
+    map.set(sessionVisible.id, sessionVisible.structure!.timezone)
+    return map
+  }, new Map<string, string>())
+}

--- a/src/application/queries/query-mappers/milo.mappers.ts
+++ b/src/application/queries/query-mappers/milo.mappers.ts
@@ -1,26 +1,54 @@
 import {
   OffreTypeCode,
-  SessionConseillerDetailDto
+  SessionConseillerDetailDto,
+  SessionJeuneDetailDto
 } from 'src/infrastructure/clients/dto/milo.dto'
 import {
   DetailSessionConseillerMiloQueryModel,
   SessionConseillerMiloQueryModel,
+  SessionJeuneMiloQueryModel,
   SessionTypeQueryModel
 } from '../query-models/sessions.milo.query.model'
 import { DateTime } from 'luxon'
 
 function buildSessionTypeQueryModel(
-  sessionDto: SessionConseillerDetailDto
+  type: OffreTypeCode
 ): SessionTypeQueryModel {
-  switch (sessionDto.offre.type) {
+  switch (type) {
     case OffreTypeCode.WORKSHOP:
-      return { code: sessionDto.offre.type, label: 'Atelier i-milo' }
+      return { code: type, label: 'Atelier i-milo' }
     case OffreTypeCode.COLLECTIVE_INFORMATION:
-      return { code: sessionDto.offre.type, label: 'info coll i-milo' }
+      return { code: type, label: 'info coll i-milo' }
   }
 }
 
-export function mapSessionDtoToQueryModel(
+export function mapSessionJeuneDtoToQueryModel(
+  sessionDto: SessionJeuneDetailDto,
+  timezone: string
+): SessionJeuneMiloQueryModel {
+  return {
+    id: sessionDto.session.id.toString(),
+    nomSession: sessionDto.session.nom,
+    nomOffre: sessionDto.offre.nom,
+    dateHeureDebut: DateTime.fromFormat(
+      sessionDto.session.dateHeureDebut,
+      'yyyy-MM-dd HH:mm:ss',
+      { zone: timezone }
+    )
+      .toUTC()
+      .toISO(),
+    dateHeureFin: DateTime.fromFormat(
+      sessionDto.session.dateHeureFin,
+      'yyyy-MM-dd HH:mm:ss',
+      { zone: timezone }
+    )
+      .toUTC()
+      .toISO(),
+    type: buildSessionTypeQueryModel(sessionDto.offre.type)
+  }
+}
+
+export function mapSessionConseillerDtoToQueryModel(
   sessionDto: SessionConseillerDetailDto,
   estVisible: boolean,
   timezone: string
@@ -44,7 +72,7 @@ export function mapSessionDtoToQueryModel(
     )
       .toUTC()
       .toISO(),
-    type: buildSessionTypeQueryModel(sessionDto)
+    type: buildSessionTypeQueryModel(sessionDto.offre.type)
   }
 }
 
@@ -82,7 +110,7 @@ export function mapDetailSessionDtoToQueryModel(
       id: sessionDto.offre.id.toString(),
       nom: sessionDto.offre.nom,
       theme: sessionDto.offre.theme,
-      type: buildSessionTypeQueryModel(sessionDto),
+      type: buildSessionTypeQueryModel(sessionDto.offre.type),
       description: sessionDto.offre.description ?? undefined,
       nomPartenaire: sessionDto.offre.nomPartenaire ?? undefined
     }

--- a/src/application/queries/query-models/sessions.milo.query.model.ts
+++ b/src/application/queries/query-models/sessions.milo.query.model.ts
@@ -1,7 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger'
 
 export class SessionTypeQueryModel {
-  @ApiProperty()
+  @ApiProperty({
+    description: '2 valeurs possibles: WORKSHOP ou COLLECTIVE_INFORMATION'
+  })
   code: string
 
   @ApiProperty()
@@ -20,6 +22,26 @@ export class SessionConseillerMiloQueryModel {
 
   @ApiProperty()
   estVisible: boolean
+
+  @ApiProperty()
+  dateHeureDebut: string
+
+  @ApiProperty()
+  dateHeureFin: string
+
+  @ApiProperty()
+  type: SessionTypeQueryModel
+}
+
+export class SessionJeuneMiloQueryModel {
+  @ApiProperty()
+  id: string
+
+  @ApiProperty()
+  nomSession: string
+
+  @ApiProperty()
+  nomOffre: string
 
   @ApiProperty()
   dateHeureDebut: string

--- a/src/building-blocks/types/domain-error.ts
+++ b/src/building-blocks/types/domain-error.ts
@@ -103,6 +103,16 @@ export class JeuneNonLieAuConseillerError implements DomainError {
   }
 }
 
+export class JeuneMiloSansIdDossier implements DomainError {
+  static CODE = 'JEUNE_MILO_SANS_ID_DOSSIER'
+  readonly code: string = JeuneMiloSansIdDossier.CODE
+  readonly message: string
+
+  constructor(idJeune: string) {
+    this.message = `Le jeune ${idJeune} n'a pas d'ID dossier`
+  }
+}
+
 export class CompteDiagorienteInvalideError implements DomainError {
   static CODE = 'COMPTE_DIAGORIENTE_INVALIDE'
   readonly code: string = CompteDiagorienteInvalideError.CODE

--- a/src/infrastructure/clients/dto/milo.dto.ts
+++ b/src/infrastructure/clients/dto/milo.dto.ts
@@ -3,32 +3,47 @@ export enum OffreTypeCode {
   COLLECTIVE_INFORMATION = 'COLLECTIVE_INFORMATION'
 }
 
+export interface SessionDto {
+  id: number
+  nom: string
+  dateHeureDebut: string
+  dateHeureFin: string
+  dateMaxInscription: string | null
+  animateur: string
+  lieu: string
+  nbPlacesDisponibles: number | null
+  commentaire: string | null
+}
+
+export interface OffreDto {
+  id: number
+  nom: string
+  theme: string
+  type: OffreTypeCode
+  description: string | null
+  nomPartenaire: string | null
+}
+
 export interface SessionConseillerDetailDto {
-  session: {
-    id: number
-    nom: string
-    dateHeureDebut: string
-    dateHeureFin: string
-    dateMaxInscription: string | null
-    animateur: string
-    lieu: string
-    nbPlacesDisponibles: number | null
-    commentaire: string | null
-  }
-  offre: {
-    id: number
-    nom: string
-    theme: string
-    type: OffreTypeCode
-    description: string | null
-    nomPartenaire: string | null
-  }
+  session: SessionDto
+  offre: OffreDto
+}
+
+export interface SessionJeuneDetailDto {
+  session: SessionDto
+  offre: OffreDto
 }
 
 export interface SessionConseillerMiloListeDto {
   page: number
   nbSessions: number
   sessions: SessionConseillerDetailDto[]
+}
+
+export interface SessionJeuneMiloListeDto {
+  page: number
+  nbSessions: number
+  sessions: SessionJeuneDetailDto[]
 }
 
 export interface StructureConseillerMiloDto {

--- a/src/infrastructure/clients/keycloak-client.ts
+++ b/src/infrastructure/clients/keycloak-client.ts
@@ -4,8 +4,8 @@ import { ConfigService } from '@nestjs/config'
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception'
 import { AxiosResponse } from '@nestjs/terminus/dist/health-indicator/http/axios.interfaces'
 import { firstValueFrom } from 'rxjs'
-import { Core, estMilo, estPoleEmploiBRSA } from '../../domain/core'
-import { buildError } from '../../utils/logger.module'
+import { Core, estMilo, estPoleEmploiBRSA } from 'src/domain/core'
+import { buildError } from 'src/utils/logger.module'
 
 @Injectable()
 export class KeycloakClient {
@@ -39,6 +39,8 @@ export class KeycloakClient {
         return this.exchangeToken(bearer, 'pe-jeune', structure)
       case Core.Structure.POLE_EMPLOI_BRSA:
         return this.exchangeToken(bearer, 'pe-brsa-jeune', structure)
+      case Core.Structure.MILO:
+        return this.exchangeToken(bearer, 'similo-jeune', structure)
     }
     throw new UnauthorizedException({
       statusCode: 401,

--- a/src/infrastructure/clients/milo-client.ts
+++ b/src/infrastructure/clients/milo-client.ts
@@ -2,16 +2,17 @@ import { HttpService } from '@nestjs/axios'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { firstValueFrom } from 'rxjs'
-import { ErreurHttp } from '../../building-blocks/types/domain-error'
+import { ErreurHttp } from 'src/building-blocks/types/domain-error'
 import {
-  Result,
   failure,
   isFailure,
+  Result,
   success
-} from '../../building-blocks/types/result'
+} from 'src/building-blocks/types/result'
 import {
   SessionConseillerDetailDto,
   SessionConseillerMiloListeDto,
+  SessionJeuneMiloListeDto,
   StructureConseillerMiloDto
 } from './dto/milo.dto'
 import { handleAxiosError } from './utils/axios-error-handler'
@@ -21,6 +22,7 @@ import { DateTime } from 'luxon'
 export class MiloClient {
   private readonly apiUrl: string
   private readonly apiKeySessionsListeConseiller: string
+  private readonly apiKeySessionsListeJeune: string
   private readonly apiKeySessionDetailConseiller: string
   private readonly apiKeyUtilisateurs: string
   private logger: Logger
@@ -33,6 +35,8 @@ export class MiloClient {
     this.apiUrl = this.configService.get('milo').url
     this.apiKeySessionsListeConseiller =
       this.configService.get('milo').apiKeySessionsListeConseiller
+    this.apiKeySessionsListeJeune =
+      this.configService.get('milo').apiKeySessionsListeJeune
     this.apiKeySessionDetailConseiller =
       this.configService.get('milo').apiKeySessionDetailConseiller
     this.apiKeyUtilisateurs = this.configService.get('milo').apiKeyUtilisateurs
@@ -59,6 +63,22 @@ export class MiloClient {
     return this.get<SessionConseillerMiloListeDto>(
       `structures/${idStructure}/sessions`,
       this.apiKeySessionsListeConseiller,
+      idpToken,
+      params
+    )
+  }
+
+  async getSessionsJeune(
+    idpToken: string,
+    idDossier: string
+  ): Promise<Result<SessionJeuneMiloListeDto>> {
+    const params = new URLSearchParams()
+    params.append('idDossier', idDossier)
+
+    // L'api ne renvoie que 50 sessions max par appel au delà, une pagination doit être mise en place. (voir doc 06/23)
+    return this.get<SessionJeuneMiloListeDto>(
+      `sessions`,
+      this.apiKeySessionsListeJeune,
       idpToken,
       params
     )

--- a/src/infrastructure/routes/conseillers.milo.controller.ts
+++ b/src/infrastructure/routes/conseillers.milo.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, Param, Put, Query } from '@nestjs/common'
 import { ApiOAuth2, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
 import { UpdateSessionMiloCommandHandler } from 'src/application/commands/milo/update-session-milo.command.handler'
 import { GetDetailSessionMiloQueryHandler } from 'src/application/queries/milo/get-detail-session.milo.query.handler.db'
-import { GetSessionsMiloQueryHandler } from 'src/application/queries/milo/get-sessions.milo.query.handler.db'
+import { GetSessionsConseillerMiloQueryHandler } from 'src/application/queries/milo/get-sessions-conseiller.milo.query.handler.db'
 import {
   DetailSessionConseillerMiloQueryModel,
   SessionConseillerMiloQueryModel
@@ -22,7 +22,7 @@ import {
 @ApiTags('Conseillers Milo')
 export class ConseillersMiloController {
   constructor(
-    private readonly getSessionsMiloQueryHandler: GetSessionsMiloQueryHandler,
+    private readonly getSessionsMiloQueryHandler: GetSessionsConseillerMiloQueryHandler,
     private readonly getDetailSessionMiloQueryHandler: GetDetailSessionMiloQueryHandler,
     private readonly updateSessionMiloCommandHandler: UpdateSessionMiloCommandHandler
   ) {}

--- a/src/infrastructure/routes/failure.handler.ts
+++ b/src/infrastructure/routes/failure.handler.ts
@@ -18,6 +18,7 @@ import {
   DroitsInsuffisants,
   EmailExisteDejaError,
   ErreurHttp,
+  JeuneMiloSansIdDossier,
   JeuneNonLieALAgenceError,
   JeuneNonLieAuConseillerError,
   JeunePasInactifError,
@@ -47,6 +48,7 @@ export function handleFailure(result: Result): void {
       case JeuneNonLieALAgenceError.CODE:
       case ConseillerSansAgenceError.CODE:
       case ConseillerMiloSansStructure.CODE:
+      case JeuneMiloSansIdDossier.CODE:
         throw new BadRequestException(result.error, result.error.message)
       case RessourceIndisponibleError.CODE:
         throw new GoneException(result.error.message)

--- a/src/infrastructure/routes/jeunes.milo.controller.ts
+++ b/src/infrastructure/routes/jeunes.milo.controller.ts
@@ -3,19 +3,22 @@ import { ApiOAuth2, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
 import { GetAccueilJeuneMiloQueryHandler } from 'src/application/queries/accueil/get-accueil-jeune-milo.query.handler.db'
 import { AccueilJeuneMiloQueryModel } from 'src/application/queries/query-models/jeunes.milo.query-model'
 
-import { isSuccess } from '../../building-blocks/types/result'
-import { Authentification } from '../../domain/authentification'
-import { Utilisateur } from '../decorators/authenticated.decorator'
+import { isSuccess } from 'src/building-blocks/types/result'
+import { Authentification } from 'src/domain/authentification'
+import { AccessToken, Utilisateur } from '../decorators/authenticated.decorator'
 import { handleFailure } from './failure.handler'
 
 import { MaintenantQueryParams } from './validation/jeunes.inputs'
+import { SessionJeuneMiloQueryModel } from 'src/application/queries/query-models/sessions.milo.query.model'
+import { GetSessionsJeuneMiloQueryHandler } from 'src/application/queries/milo/get-sessions-jeune.milo.query.handler.db'
 
 @Controller('jeunes')
 @ApiOAuth2([])
 @ApiTags('Jeunes')
 export class JeunesMiloController {
   constructor(
-    private readonly getAccueilJeuneMiloQueryHandler: GetAccueilJeuneMiloQueryHandler
+    private readonly getAccueilJeuneMiloQueryHandler: GetAccueilJeuneMiloQueryHandler,
+    private readonly getSessionsJeuneMiloQueryHandler: GetSessionsJeuneMiloQueryHandler
   ) {}
 
   @Get(':idJeune/milo/accueil')
@@ -33,6 +36,32 @@ export class JeunesMiloController {
   ): Promise<AccueilJeuneMiloQueryModel> {
     const result = await this.getAccueilJeuneMiloQueryHandler.execute(
       { idJeune, maintenant: queryParams.maintenant },
+      utilisateur
+    )
+
+    if (isSuccess(result)) {
+      return result.data
+    }
+    throw handleFailure(result)
+  }
+
+  @ApiOperation({
+    summary:
+      "Récupère la liste des sessions d'un jeune MILO que les conseillers ont rendu visibles",
+    description: 'Autorisé pour les jeunes Milo'
+  })
+  @Get('/milo/:idJeune/sessions')
+  @ApiResponse({
+    type: SessionJeuneMiloQueryModel,
+    isArray: true
+  })
+  async getSessions(
+    @Param('idJeune') idJeune: string,
+    @Utilisateur() utilisateur: Authentification.Utilisateur,
+    @AccessToken() accessToken: string
+  ): Promise<SessionJeuneMiloQueryModel[]> {
+    const result = await this.getSessionsJeuneMiloQueryHandler.execute(
+      { idJeune, token: accessToken },
       utilisateur
     )
 

--- a/src/infrastructure/sequelize/models/session-milo.sql-model.ts
+++ b/src/infrastructure/sequelize/models/session-milo.sql-model.ts
@@ -1,4 +1,5 @@
 import {
+  BelongsTo,
   Column,
   DataType,
   ForeignKey,
@@ -31,4 +32,7 @@ export class SessionMiloDto extends Model {
 }
 
 @Table({ timestamps: false, tableName: 'session_milo' })
-export class SessionMiloSqlModel extends SessionMiloDto {}
+export class SessionMiloSqlModel extends SessionMiloDto {
+  @BelongsTo(() => StructureMiloSqlModel, 'id_structure_milo')
+  structure?: StructureMiloSqlModel
+}

--- a/test/application/queries/milo/get-detail-session.milo.query.handler.db.test.ts
+++ b/test/application/queries/milo/get-detail-session.milo.query.handler.db.test.ts
@@ -1,6 +1,6 @@
 import { StubbedType, stubInterface } from '@salesforce/ts-sinon'
 import { describe } from 'mocha'
-import { SinonSandbox, createSandbox } from 'sinon'
+import { createSandbox, SinonSandbox } from 'sinon'
 import { ConseillerAuthorizer } from 'src/application/authorizers/conseiller-authorizer'
 import { ConseillerMiloSansStructure } from 'src/building-blocks/types/domain-error'
 import { failure, success } from 'src/building-blocks/types/result'
@@ -10,7 +10,7 @@ import { MiloClient } from 'src/infrastructure/clients/milo-client'
 import { unUtilisateurConseiller } from 'test/fixtures/authentification.fixture'
 import { unConseillerMilo } from 'test/fixtures/conseiller-milo.fixture'
 import { unDetailSessionConseillerDto } from 'test/fixtures/milo-dto.fixture'
-import { StubbedClass, expect, stubClass } from 'test/utils'
+import { expect, StubbedClass, stubClass } from 'test/utils'
 import { GetDetailSessionMiloQueryHandler } from 'src/application/queries/milo/get-detail-session.milo.query.handler.db'
 import { unDetailSessionConseillerMiloQueryModel } from 'test/fixtures/sessions.fixture'
 import { StructureMiloSqlModel } from 'src/infrastructure/sequelize/models/structure-milo.sql-model'
@@ -124,7 +124,7 @@ describe('GetDetailSessionMiloQueryHandler', () => {
 
         // Then
         expect(result).to.deep.equal(
-          success(unDetailSessionConseillerMiloQueryModel())
+          success(unDetailSessionConseillerMiloQueryModel)
         )
       })
 
@@ -149,9 +149,9 @@ describe('GetDetailSessionMiloQueryHandler', () => {
           // Then
           expect(result).to.deep.equal(
             success({
-              ...unDetailSessionConseillerMiloQueryModel(),
+              ...unDetailSessionConseillerMiloQueryModel,
               session: {
-                ...unDetailSessionConseillerMiloQueryModel().session,
+                ...unDetailSessionConseillerMiloQueryModel.session,
                 estVisible: true
               }
             })

--- a/test/application/queries/milo/get-sessions-conseiller.milo.query.handler.db.test.ts
+++ b/test/application/queries/milo/get-sessions-conseiller.milo.query.handler.db.test.ts
@@ -1,8 +1,8 @@
 import { StubbedType, stubInterface } from '@salesforce/ts-sinon'
 import { describe } from 'mocha'
-import { SinonSandbox, createSandbox } from 'sinon'
+import { createSandbox, SinonSandbox } from 'sinon'
 import { ConseillerAuthorizer } from 'src/application/authorizers/conseiller-authorizer'
-import { GetSessionsMiloQueryHandler } from 'src/application/queries/milo/get-sessions.milo.query.handler.db'
+import { GetSessionsConseillerMiloQueryHandler } from 'src/application/queries/milo/get-sessions-conseiller.milo.query.handler.db'
 import { ConseillerMiloSansStructure } from 'src/building-blocks/types/domain-error'
 import { failure, success } from 'src/building-blocks/types/result'
 import { ConseillerMilo } from 'src/domain/milo/conseiller.milo'
@@ -15,14 +15,14 @@ import {
   uneSessionConseillerListeDto
 } from 'test/fixtures/milo-dto.fixture'
 import { uneSessionConseillerMiloQueryModel } from 'test/fixtures/sessions.fixture'
-import { StubbedClass, expect, stubClass } from 'test/utils'
+import { expect, StubbedClass, stubClass } from 'test/utils'
 import { SessionMiloSqlModel } from 'src/infrastructure/sequelize/models/session-milo.sql-model'
 import { DateTime } from 'luxon'
 import { StructureMiloSqlModel } from 'src/infrastructure/sequelize/models/structure-milo.sql-model'
 import { getDatabase } from 'test/utils/database-for-testing'
 
-describe('GetSessionsQueryHandler', () => {
-  let getSessionsQueryHandler: GetSessionsMiloQueryHandler
+describe('GetSessionsConseillerMiloQueryHandler', () => {
+  let getSessionsQueryHandler: GetSessionsConseillerMiloQueryHandler
   let miloClient: StubbedClass<MiloClient>
   let keycloakClient: StubbedClass<KeycloakClient>
   let conseillerRepository: StubbedType<ConseillerMilo.Repository>
@@ -38,7 +38,7 @@ describe('GetSessionsQueryHandler', () => {
     keycloakClient = stubClass(KeycloakClient)
     conseillerRepository = stubInterface(sandbox)
     conseillerAuthorizer = stubClass(ConseillerAuthorizer)
-    getSessionsQueryHandler = new GetSessionsMiloQueryHandler(
+    getSessionsQueryHandler = new GetSessionsConseillerMiloQueryHandler(
       miloClient,
       conseillerRepository,
       conseillerAuthorizer,
@@ -151,9 +151,7 @@ describe('GetSessionsQueryHandler', () => {
 
         // Then
         expect(result).to.deep.equal(
-          success([
-            { ...uneSessionConseillerMiloQueryModel(), estVisible: true }
-          ])
+          success([{ ...uneSessionConseillerMiloQueryModel, estVisible: true }])
         )
       })
 
@@ -193,7 +191,7 @@ describe('GetSessionsQueryHandler', () => {
         expect(result).to.deep.equal(
           success([
             {
-              ...uneSessionConseillerMiloQueryModel(),
+              ...uneSessionConseillerMiloQueryModel,
               id: '2',
               estVisible: false
             }

--- a/test/application/queries/milo/get-sessions-jeune.milo.query.handler.db.test.ts
+++ b/test/application/queries/milo/get-sessions-jeune.milo.query.handler.db.test.ts
@@ -1,0 +1,211 @@
+import { describe } from 'mocha'
+import { createSandbox, SinonSandbox } from 'sinon'
+import { unUtilisateurJeune } from 'test/fixtures/authentification.fixture'
+import { expect, StubbedClass, stubClass } from 'test/utils'
+import { GetSessionsJeuneMiloQueryHandler } from 'src/application/queries/milo/get-sessions-jeune.milo.query.handler.db'
+import { JeuneAuthorizer } from 'src/application/authorizers/jeune-authorizer'
+import { Jeune } from 'src/domain/jeune/jeune'
+import { StubbedType, stubInterface } from '@salesforce/ts-sinon'
+import { failure, success } from 'src/building-blocks/types/result'
+import {
+  JeuneMiloSansIdDossier,
+  NonTrouveError
+} from 'src/building-blocks/types/domain-error'
+import { unJeune } from 'test/fixtures/jeune.fixture'
+import { KeycloakClient } from 'src/infrastructure/clients/keycloak-client'
+import { MiloClient } from 'src/infrastructure/clients/milo-client'
+import { uneSessionJeuneMiloQueryModel } from 'test/fixtures/sessions.fixture'
+import { uneOffreDto, uneSessionDto } from 'test/fixtures/milo-dto.fixture'
+import { StructureMiloSqlModel } from 'src/infrastructure/sequelize/models/structure-milo.sql-model'
+import { SessionMiloSqlModel } from 'src/infrastructure/sequelize/models/session-milo.sql-model'
+import { DateTime } from 'luxon'
+import { getDatabase } from 'test/utils/database-for-testing'
+
+describe('GetSessionsJeuneMiloQueryHandler', () => {
+  const query = { idJeune: 'idJeune', token: 'token' }
+  const jeune = unJeune()
+  const utilisateur = unUtilisateurJeune()
+
+  let getSessionsQueryHandler: GetSessionsJeuneMiloQueryHandler
+  let jeuneRepository: StubbedType<Jeune.Repository>
+  let keycloakClient: StubbedClass<KeycloakClient>
+  let miloClient: StubbedClass<MiloClient>
+  let jeuneAuthorizer: StubbedClass<JeuneAuthorizer>
+  let sandbox: SinonSandbox
+
+  before(async () => {
+    sandbox = createSandbox()
+  })
+
+  beforeEach(async () => {
+    jeuneRepository = stubInterface(sandbox)
+    keycloakClient = stubClass(KeycloakClient)
+    miloClient = stubClass(MiloClient)
+    jeuneAuthorizer = stubClass(JeuneAuthorizer)
+    getSessionsQueryHandler = new GetSessionsJeuneMiloQueryHandler(
+      jeuneRepository,
+      keycloakClient,
+      miloClient,
+      jeuneAuthorizer
+    )
+  })
+
+  after(() => {
+    sandbox.restore()
+  })
+
+  describe('authorize', () => {
+    it('autorise un jeune Milo', () => {
+      // When
+      getSessionsQueryHandler.authorize(query, utilisateur)
+
+      // Then
+      expect(jeuneAuthorizer.autoriserLeJeune).to.have.been.calledWithExactly(
+        'idJeune',
+        utilisateur,
+        true
+      )
+    })
+  })
+
+  describe('handle', () => {
+    describe("quand le jeune n'existe pas", () => {
+      it('renvoie une failure ', async () => {
+        // Given
+        jeuneRepository.get.withArgs(query.idJeune).resolves(undefined)
+
+        // When
+        const result = await getSessionsQueryHandler.handle(query)
+
+        // Then
+        expect(result).to.deep.equal(
+          failure(new NonTrouveError('Jeune', query.idJeune))
+        )
+      })
+    })
+
+    describe('quand le jeune existe sans ID partenaire', () => {
+      it('renvoie une failure ', async () => {
+        // Given
+        jeuneRepository.get
+          .withArgs(query.idJeune)
+          .resolves({ ...jeune, idPartenaire: undefined })
+
+        // When
+        const result = await getSessionsQueryHandler.handle(query)
+
+        // Then
+        expect(result).to.deep.equal(
+          failure(new JeuneMiloSansIdDossier(query.idJeune))
+        )
+      })
+    })
+
+    describe('quand le jeune existe avec un ID partenaire', () => {
+      const idpToken = 'idpToken'
+      const idStructureParis = 'id-paris'
+      const idStructureCayenne = 'id-cayenne'
+      const idSession1 = 1
+      const idSession2 = 2
+      const idSession3 = 3
+
+      beforeEach(async () => {
+        jeuneRepository.get.withArgs(query.idJeune).resolves(jeune)
+        keycloakClient.exchangeTokenJeune
+          .withArgs(query.token, jeune.structure)
+          .resolves(idpToken)
+
+        await StructureMiloSqlModel.create({
+          id: idStructureParis,
+          nomOfficiel: 'Paris',
+          timezone: 'Europe/Paris'
+        })
+        await StructureMiloSqlModel.create({
+          id: idStructureCayenne,
+          nomOfficiel: 'Cayenne',
+          timezone: 'America/Cayenne'
+        })
+        await SessionMiloSqlModel.create({
+          id: idSession2,
+          estVisible: true,
+          idStructureMilo: idStructureParis,
+          dateModification: DateTime.now().toJSDate()
+        })
+        await SessionMiloSqlModel.create({
+          id: idSession3,
+          estVisible: true,
+          idStructureMilo: idStructureCayenne,
+          dateModification: DateTime.now().toJSDate()
+        })
+      })
+
+      afterEach(async () => {
+        await getDatabase().cleanPG()
+      })
+
+      describe('récupère la liste des sessions du jeune et les retourne', () => {
+        const sessionNonVisible = { ...uneSessionDto, id: idSession1 }
+        const sessionVisibleAParis = { ...uneSessionDto, id: idSession2 }
+        const sessionVisibleACayenne = { ...uneSessionDto, id: idSession3 }
+
+        it('seulement si elles sont visibles', async () => {
+          // Given
+          miloClient.getSessionsJeune
+            .withArgs(idpToken, jeune.idPartenaire)
+            .resolves(
+              success({
+                page: 1,
+                nbSessions: 1,
+                sessions: [
+                  { session: sessionNonVisible, offre: uneOffreDto },
+                  { session: sessionVisibleACayenne, offre: uneOffreDto }
+                ]
+              })
+            )
+
+          // When
+          const result = await getSessionsQueryHandler.handle(query)
+
+          // Then
+          expect(result).to.deep.equal(
+            success([
+              { ...uneSessionJeuneMiloQueryModel, id: idSession3.toString() }
+            ])
+          )
+        })
+
+        it('à la timezone de leur structure', async () => {
+          // Given
+          miloClient.getSessionsJeune
+            .withArgs(idpToken, jeune.idPartenaire)
+            .resolves(
+              success({
+                page: 1,
+                nbSessions: 1,
+                sessions: [
+                  { session: sessionVisibleAParis, offre: uneOffreDto }
+                ]
+              })
+            )
+
+          // When
+          const result = await getSessionsQueryHandler.handle(query)
+
+          // Then
+          const dateHeureDebutTimeZoneParis = '2020-04-06T08:20:00.000Z'
+          const dateHeureFinTimeZoneParis = '2020-04-08T08:20:00.000Z'
+          expect(result).to.deep.equal(
+            success([
+              {
+                ...uneSessionJeuneMiloQueryModel,
+                id: idSession2.toString(),
+                dateHeureDebut: dateHeureDebutTimeZoneParis,
+                dateHeureFin: dateHeureFinTimeZoneParis
+              }
+            ])
+          )
+        })
+      })
+    })
+  })
+})

--- a/test/fixtures/milo-dto.fixture.ts
+++ b/test/fixtures/milo-dto.fixture.ts
@@ -1,35 +1,55 @@
 import {
+  OffreDto,
   OffreTypeCode,
+  SessionConseillerDetailDto,
   SessionConseillerMiloListeDto,
+  SessionDto,
+  SessionJeuneDetailDto,
+  SessionJeuneMiloListeDto,
   StructureConseillerMiloDto
-} from '../../src/infrastructure/clients/dto/milo.dto'
+} from 'src/infrastructure/clients/dto/milo.dto'
 
-export const unDetailSessionConseillerDto = {
-  session: {
-    id: 1,
-    nom: 'Une-session',
-    dateHeureDebut: '2020-04-06 10:20:00',
-    dateHeureFin: '2020-04-08 10:20:00',
-    dateMaxInscription: '2020-04-07T10:20:00.000Z',
-    animateur: 'Un-animateur',
-    lieu: 'Un-lieu',
-    nbPlacesDisponibles: 10,
-    commentaire: 'Un-commentaire'
-  },
-  offre: {
-    id: 1,
-    nom: 'Une-offre',
-    theme: 'Un-theme',
-    type: 'WORKSHOP' as OffreTypeCode,
-    description: 'Une-Desc',
-    nomPartenaire: 'Un-partenaire'
-  }
+export const uneSessionDto: SessionDto = {
+  id: 1,
+  nom: 'Une-session',
+  dateHeureDebut: '2020-04-06 10:20:00',
+  dateHeureFin: '2020-04-08 10:20:00',
+  dateMaxInscription: '2020-04-07T10:20:00.000Z',
+  animateur: 'Un-animateur',
+  lieu: 'Un-lieu',
+  nbPlacesDisponibles: 10,
+  commentaire: 'Un-commentaire'
+}
+
+export const uneOffreDto: OffreDto = {
+  id: 1,
+  nom: 'Une-offre',
+  theme: 'Un-theme',
+  type: 'WORKSHOP' as OffreTypeCode,
+  description: 'Une-Desc',
+  nomPartenaire: 'Un-partenaire'
+}
+
+export const unDetailSessionConseillerDto: SessionConseillerDetailDto = {
+  session: uneSessionDto,
+  offre: uneOffreDto
+}
+
+export const unDetailSessionJeuneDto: SessionJeuneDetailDto = {
+  session: uneSessionDto,
+  offre: uneOffreDto
 }
 
 export const uneSessionConseillerListeDto: SessionConseillerMiloListeDto = {
   page: 1,
   nbSessions: 1,
   sessions: [unDetailSessionConseillerDto]
+}
+
+export const uneSessionJeuneListeDto: SessionJeuneMiloListeDto = {
+  page: 1,
+  nbSessions: 1,
+  sessions: [unDetailSessionJeuneDto]
 }
 
 export const uneStructureConseillerMiloDto = (

--- a/test/fixtures/sessions.fixture.ts
+++ b/test/fixtures/sessions.fixture.ts
@@ -1,47 +1,56 @@
 import {
   DetailSessionConseillerMiloQueryModel,
-  SessionConseillerMiloQueryModel
+  SessionConseillerMiloQueryModel,
+  SessionJeuneMiloQueryModel
 } from 'src/application/queries/query-models/sessions.milo.query.model'
 import { OffreTypeCode } from 'src/infrastructure/clients/dto/milo.dto'
 
-export const uneSessionConseillerMiloQueryModel =
-  (): SessionConseillerMiloQueryModel => {
-    return {
-      id: '1',
-      nomSession: 'Une-session',
-      nomOffre: 'Une-offre',
-      estVisible: false,
-      dateHeureDebut: '2020-04-06T13:20:00.000Z',
-      dateHeureFin: '2020-04-08T13:20:00.000Z',
-      type: {
-        code: OffreTypeCode.WORKSHOP,
-        label: 'Atelier i-milo'
-      }
+export const uneSessionConseillerMiloQueryModel: SessionConseillerMiloQueryModel =
+  {
+    id: '1',
+    nomSession: 'Une-session',
+    nomOffre: 'Une-offre',
+    estVisible: false,
+    dateHeureDebut: '2020-04-06T13:20:00.000Z',
+    dateHeureFin: '2020-04-08T13:20:00.000Z',
+    type: {
+      code: OffreTypeCode.WORKSHOP,
+      label: 'Atelier i-milo'
     }
   }
 
-export const unDetailSessionConseillerMiloQueryModel =
-  (): DetailSessionConseillerMiloQueryModel => {
-    return {
-      session: {
-        id: '1',
-        nom: 'Une-session',
-        dateHeureDebut: '2020-04-06T13:20:00.000Z',
-        dateHeureFin: '2020-04-08T13:20:00.000Z',
-        dateMaxInscription: '2020-04-07T10:20:00.000Z',
-        animateur: 'Un-animateur',
-        lieu: 'Un-lieu',
-        estVisible: false,
-        nbPlacesDisponibles: 10,
-        commentaire: 'Un-commentaire'
-      },
-      offre: {
-        id: '1',
-        nom: 'Une-offre',
-        theme: 'Un-theme',
-        type: { code: OffreTypeCode.WORKSHOP, label: 'Atelier i-milo' },
-        description: 'Une-Desc',
-        nomPartenaire: 'Un-partenaire'
-      }
+export const uneSessionJeuneMiloQueryModel: SessionJeuneMiloQueryModel = {
+  id: '1',
+  nomSession: 'Une-session',
+  nomOffre: 'Une-offre',
+  dateHeureDebut: '2020-04-06T13:20:00.000Z',
+  dateHeureFin: '2020-04-08T13:20:00.000Z',
+  type: {
+    code: OffreTypeCode.WORKSHOP,
+    label: 'Atelier i-milo'
+  }
+}
+
+export const unDetailSessionConseillerMiloQueryModel: DetailSessionConseillerMiloQueryModel =
+  {
+    session: {
+      id: '1',
+      nom: 'Une-session',
+      dateHeureDebut: '2020-04-06T13:20:00.000Z',
+      dateHeureFin: '2020-04-08T13:20:00.000Z',
+      dateMaxInscription: '2020-04-07T10:20:00.000Z',
+      animateur: 'Un-animateur',
+      lieu: 'Un-lieu',
+      estVisible: false,
+      nbPlacesDisponibles: 10,
+      commentaire: 'Un-commentaire'
+    },
+    offre: {
+      id: '1',
+      nom: 'Une-offre',
+      theme: 'Un-theme',
+      type: { code: OffreTypeCode.WORKSHOP, label: 'Atelier i-milo' },
+      description: 'Une-Desc',
+      nomPartenaire: 'Un-partenaire'
     }
   }

--- a/test/infrastructure/clients/milo-client.test.ts
+++ b/test/infrastructure/clients/milo-client.test.ts
@@ -1,14 +1,15 @@
 import { HttpService } from '@nestjs/axios'
 import { expect } from 'chai'
 import * as nock from 'nock'
-import { MiloClient } from '../../../src/infrastructure/clients/milo-client'
-import { testConfig } from '../../utils/module-for-testing'
+import { MiloClient } from 'src/infrastructure/clients/milo-client'
+import { testConfig } from 'test/utils/module-for-testing'
 import {
   unDetailSessionConseillerDto,
   uneListeDeStructuresConseillerMiloDto,
-  uneSessionConseillerListeDto
-} from '../../fixtures/milo-dto.fixture'
-import { success } from '../../../src/building-blocks/types/result'
+  uneSessionConseillerListeDto,
+  uneSessionJeuneListeDto
+} from 'test/fixtures/milo-dto.fixture'
+import { success } from 'src/building-blocks/types/result'
 import { DateTime } from 'luxon'
 
 describe('MiloClient', () => {
@@ -45,6 +46,25 @@ describe('MiloClient', () => {
 
       // Then
       expect(result).to.deep.equal(success(uneSessionConseillerListeDto))
+    })
+  })
+
+  describe('getSessionsJeune', () => {
+    it('recupere la liste des sessions milo accessible au jeune', async () => {
+      // Given
+      const idpToken = 'idpToken'
+      const idDossier = 'idDossier'
+
+      nock(MILO_BASE_URL)
+        .get(`/operateurs/sessions?idDossier=${idDossier}`)
+        .reply(200, uneSessionJeuneListeDto)
+        .isDone()
+
+      // When
+      const result = await miloClient.getSessionsJeune(idpToken, idDossier)
+
+      // Then
+      expect(result).to.deep.equal(success(uneSessionJeuneListeDto))
     })
   })
 

--- a/test/infrastructure/routes/conseillers.milo.controller.test.ts
+++ b/test/infrastructure/routes/conseillers.milo.controller.test.ts
@@ -1,8 +1,8 @@
 import { ensureUserAuthenticationFailsIfInvalid } from 'test/utils/ensure-user-authentication-fails-if-invalid'
 import { HttpStatus, INestApplication } from '@nestjs/common'
 import { getApplicationWithStubbedDependencies } from 'test/utils/module-for-testing'
-import { GetSessionsMiloQueryHandler } from 'src/application/queries/milo/get-sessions.milo.query.handler.db'
-import { StubbedClass, expect } from 'test/utils'
+import { GetSessionsConseillerMiloQueryHandler } from 'src/application/queries/milo/get-sessions-conseiller.milo.query.handler.db'
+import { expect, StubbedClass } from 'test/utils'
 import {
   unHeaderAuthorization,
   unUtilisateurDecode
@@ -25,7 +25,7 @@ import {
 } from 'src/application/commands/milo/update-session-milo.command.handler'
 
 describe('ConseillersMiloController', () => {
-  let getSessionsMiloQueryHandler: StubbedClass<GetSessionsMiloQueryHandler>
+  let getSessionsMiloQueryHandler: StubbedClass<GetSessionsConseillerMiloQueryHandler>
   let getDetailSessionMiloQueryHandler: StubbedClass<GetDetailSessionMiloQueryHandler>
   let updateVisibiliteSessionCommandHandler: StubbedClass<UpdateSessionMiloCommandHandler>
 
@@ -34,7 +34,7 @@ describe('ConseillersMiloController', () => {
   before(async () => {
     app = await getApplicationWithStubbedDependencies()
 
-    getSessionsMiloQueryHandler = app.get(GetSessionsMiloQueryHandler)
+    getSessionsMiloQueryHandler = app.get(GetSessionsConseillerMiloQueryHandler)
     getDetailSessionMiloQueryHandler = app.get(GetDetailSessionMiloQueryHandler)
     updateVisibiliteSessionCommandHandler = app.get(
       UpdateSessionMiloCommandHandler
@@ -46,7 +46,7 @@ describe('ConseillersMiloController', () => {
       it('renvoie une 200', async () => {
         // Given
         getSessionsMiloQueryHandler.execute.resolves(
-          success([uneSessionConseillerMiloQueryModel()])
+          success([uneSessionConseillerMiloQueryModel])
         )
 
         // When - Then
@@ -54,7 +54,7 @@ describe('ConseillersMiloController', () => {
           .get('/conseillers/milo/id-conseiller/sessions')
           .set('authorization', unHeaderAuthorization())
           .expect(HttpStatus.OK)
-          .expect([uneSessionConseillerMiloQueryModel()])
+          .expect([uneSessionConseillerMiloQueryModel])
 
         expect(
           getSessionsMiloQueryHandler.execute
@@ -95,7 +95,7 @@ describe('ConseillersMiloController', () => {
       // Given
       const idSession = '123'
       getDetailSessionMiloQueryHandler.execute.resolves(
-        success(unDetailSessionConseillerMiloQueryModel())
+        success(unDetailSessionConseillerMiloQueryModel)
       )
 
       // When - Then
@@ -103,7 +103,7 @@ describe('ConseillersMiloController', () => {
         .get(`/conseillers/milo/id-conseiller/sessions/${idSession}`)
         .set('authorization', unHeaderAuthorization())
         .expect(HttpStatus.OK)
-        .expect(unDetailSessionConseillerMiloQueryModel())
+        .expect(unDetailSessionConseillerMiloQueryModel)
 
       expect(
         getDetailSessionMiloQueryHandler.execute


### PR DESCRIPTION
**TODO**
- [x] Controller + test
- [x] QueryHandler + test
- [x] Token Exchange Jeune milo + test
- [x] Milo client + API KEY par env + test
- [x] N'afficher que les sessions visibles
- [x] Gestion de la timezone : va chercher celle de la structure de la session
- [x] Mettre les valeurs de OffreTypeCode en ApiProperty

**Question en suspens**
- [ ] Gestion de la pagination ? Pas faite non plus pour les conseillers, on crée les US pour ne pas oublier ?
- [ ] J'ai créé un modèle à part pour la session jeune que la session conseiller, juste pour ne pas afficher la visibilité. Il y aura peut-être la même chose pour le détail. On est bien d'accord sur ça ?
- [ ] Pareil, j'ai crée un modèle à part pour les DTO, puisqu'à terme les instance de sessions seront différentes pour jeunes et conseiller (je pense ?). YAGNI ou pas ?