### PR TITLE
feat(session): 204 - Affichage des tags pour le statut des sessions ( liste et détail ) - Etape 1

### DIFF
--- a/src/application/commands/creer-jeune-milo.command.handler.ts
+++ b/src/application/commands/creer-jeune-milo.command.handler.ts
@@ -8,9 +8,9 @@ import {
   NonTrouveError
 } from '../../building-blocks/types/domain-error'
 import {
-  Result,
   failure,
   isFailure,
+  Result,
   success
 } from '../../building-blocks/types/result'
 import {

--- a/src/application/queries/milo/get-detail-session-conseiller.milo.query.handler.db.ts
+++ b/src/application/queries/milo/get-detail-session-conseiller.milo.query.handler.db.ts
@@ -14,6 +14,7 @@ import {
 import { ConseillerAuthorizer } from '../../authorizers/conseiller-authorizer'
 import { mapSessionToDetailSessionConseillerQueryModel } from '../query-mappers/milo.mappers'
 import { DetailSessionConseillerMiloQueryModel } from '../query-models/sessions.milo.query.model'
+import { DateService } from 'src/utils/date-service'
 
 export interface GetDetailSessionConseillerMiloQuery extends Query {
   idSession: string
@@ -32,7 +33,8 @@ export class GetDetailSessionConseillerMiloQueryHandler extends QueryHandler<
     @Inject(SessionMiloRepositoryToken)
     private sessionRepository: SessionMilo.Repository,
     private conseillerAuthorizer: ConseillerAuthorizer,
-    private keycloakClient: KeycloakClient
+    private keycloakClient: KeycloakClient,
+    private dateService: DateService
   ) {
     super('GetDetailSessionMiloQueryHandler')
   }
@@ -59,7 +61,12 @@ export class GetDetailSessionConseillerMiloQueryHandler extends QueryHandler<
     )
     if (isFailure(resultat)) return resultat
 
-    return success(mapSessionToDetailSessionConseillerQueryModel(resultat.data))
+    return success(
+      mapSessionToDetailSessionConseillerQueryModel(
+        resultat.data,
+        this.dateService.now()
+      )
+    )
   }
 
   async authorize(

--- a/src/application/queries/milo/get-sessions-conseiller.milo.query.handler.db.ts
+++ b/src/application/queries/milo/get-sessions-conseiller.milo.query.handler.db.ts
@@ -13,6 +13,7 @@ import { ConseillerAuthorizer } from '../../authorizers/conseiller-authorizer'
 import { mapSessionConseillerDtoToQueryModel } from '../query-mappers/milo.mappers'
 import { SessionConseillerMiloQueryModel } from '../query-models/sessions.milo.query.model'
 import { SessionMiloSqlModel } from 'src/infrastructure/sequelize/models/session-milo.sql-model'
+import { DateService } from 'src/utils/date-service'
 
 export interface GetSessionsConseillerMiloQuery extends Query {
   idConseiller: string
@@ -31,7 +32,8 @@ export class GetSessionsConseillerMiloQueryHandler extends QueryHandler<
     @Inject(ConseillerMiloRepositoryToken)
     private conseillerMiloRepository: Conseiller.Milo.Repository,
     private conseillerAuthorizer: ConseillerAuthorizer,
-    private keycloakClient: KeycloakClient
+    private keycloakClient: KeycloakClient,
+    private dateService: DateService
   ) {
     super('GetSessionsConseillerMiloQueryHandler')
   }
@@ -71,10 +73,13 @@ export class GetSessionsConseillerMiloQueryHandler extends QueryHandler<
         const sessionSqlModel = sessionsSqlModels.find(
           ({ id }) => id === sessionMilo.session.id.toString()
         )
+        const dateCloture = sessionSqlModel?.dateCloture
         return mapSessionConseillerDtoToQueryModel(
           sessionMilo,
           sessionSqlModel?.estVisible ?? false,
-          timezoneStructure
+          timezoneStructure,
+          this.dateService.now(),
+          dateCloture ? DateTime.fromJSDate(dateCloture) : undefined
         )
       }
     )

--- a/src/application/queries/query-mappers/milo.mappers.ts
+++ b/src/application/queries/query-mappers/milo.mappers.ts
@@ -140,7 +140,8 @@ export function mapDetailSessionJeuneDtoToQueryModel(
 }
 
 export function mapSessionToDetailSessionConseillerQueryModel(
-  session: SessionMilo
+  session: SessionMilo,
+  maintenant: DateTime
 ): DetailSessionConseillerMiloQueryModel {
   const sessionQueryModel: DetailSessionConseillerQueryModel = {
     id: session.id,
@@ -149,7 +150,12 @@ export function mapSessionToDetailSessionConseillerQueryModel(
     dateHeureFin: session.fin.toUTC().toISO(),
     animateur: session.animateur,
     lieu: session.lieu,
-    estVisible: session.estVisible
+    estVisible: session.estVisible,
+    statut: SessionMilo.calculerStatut(
+      maintenant,
+      session.fin,
+      session.dateCloture
+    )
   }
 
   if (session.dateMaxInscription)

--- a/src/application/queries/query-mappers/milo.mappers.ts
+++ b/src/application/queries/query-mappers/milo.mappers.ts
@@ -68,8 +68,15 @@ export function mapSessionJeuneDtoToQueryModel(
 export function mapSessionConseillerDtoToQueryModel(
   sessionDto: SessionConseillerDetailDto,
   estVisible: boolean,
-  timezone: string
+  timezone: string,
+  maintenant: DateTime,
+  dateCloture?: DateTime
 ): SessionConseillerMiloQueryModel {
+  const dateHeureFin = DateTime.fromFormat(
+    sessionDto.session.dateHeureFin,
+    MILO_DATE_FORMAT,
+    { zone: timezone }
+  ).toUTC()
   return {
     id: sessionDto.session.id.toString(),
     nomSession: sessionDto.session.nom,
@@ -82,14 +89,9 @@ export function mapSessionConseillerDtoToQueryModel(
     )
       .toUTC()
       .toISO(),
-    dateHeureFin: DateTime.fromFormat(
-      sessionDto.session.dateHeureFin,
-      MILO_DATE_FORMAT,
-      { zone: timezone }
-    )
-      .toUTC()
-      .toISO(),
-    type: buildSessionTypeQueryModel(sessionDto.offre.type)
+    dateHeureFin: dateHeureFin.toISO(),
+    type: buildSessionTypeQueryModel(sessionDto.offre.type),
+    statut: SessionMilo.calculerStatut(maintenant, dateHeureFin, dateCloture)
   }
 }
 

--- a/src/application/queries/query-models/sessions.milo.query.model.ts
+++ b/src/application/queries/query-models/sessions.milo.query.model.ts
@@ -32,6 +32,9 @@ export class SessionConseillerMiloQueryModel {
 
   @ApiProperty()
   type: SessionTypeQueryModel
+
+  @ApiProperty({ enum: SessionMilo.Statut })
+  statut: SessionMilo.Statut
 }
 
 export class SessionJeuneMiloQueryModel {

--- a/src/application/queries/query-models/sessions.milo.query.model.ts
+++ b/src/application/queries/query-models/sessions.milo.query.model.ts
@@ -87,6 +87,9 @@ export class DetailSessionConseillerQueryModel {
 
   @ApiProperty({ required: false })
   commentaire?: string
+
+  @ApiProperty({ enum: SessionMilo.Statut })
+  statut: SessionMilo.Statut
 }
 
 class OffreSessionQueryModel {

--- a/src/domain/milo/session.milo.ts
+++ b/src/domain/milo/session.milo.ts
@@ -71,6 +71,17 @@ export namespace SessionMilo {
     return success(inscriptionsATraiter)
   }
 
+  export function calculerStatut(
+    maintenant: DateTime,
+    dateFin: DateTime,
+    dateCloture?: DateTime
+  ): SessionMilo.Statut {
+    if (dateFin > maintenant) return SessionMilo.Statut.A_VENIR
+    return dateCloture
+      ? SessionMilo.Statut.CLOTUREE
+      : SessionMilo.Statut.A_CLOTURER
+  }
+
   export interface Repository {
     getForConseiller(
       idSession: string,
@@ -88,6 +99,12 @@ export namespace SessionMilo {
       inscriptionsATraiter: InscriptionsATraiter,
       tokenMilo: string
     ): Promise<Result>
+  }
+
+  export enum Statut {
+    A_VENIR = 'A_VENIR',
+    A_CLOTURER = 'A_CLOTURER',
+    CLOTUREE = 'CLOTUREE'
   }
 
   export type Offre = {

--- a/src/domain/milo/session.milo.ts
+++ b/src/domain/milo/session.milo.ts
@@ -76,9 +76,9 @@ export namespace SessionMilo {
     dateFin: DateTime,
     dateCloture?: DateTime
   ): SessionMilo.Statut {
-    if (dateFin > maintenant) return SessionMilo.Statut.A_VENIR
-    return dateCloture
-      ? SessionMilo.Statut.CLOTUREE
+    if (dateCloture) return SessionMilo.Statut.CLOTUREE
+    return maintenant < dateFin
+      ? SessionMilo.Statut.A_VENIR
       : SessionMilo.Statut.A_CLOTURER
   }
 

--- a/test/application/queries/milo/get-detail-session-conseiller.milo.query.handler.db.test.ts
+++ b/test/application/queries/milo/get-detail-session-conseiller.milo.query.handler.db.test.ts
@@ -158,11 +158,37 @@ describe('GetDetailSessionConseillerMiloQueryHandler', () => {
       })
 
       describe('et lui affecte le statut ', () => {
-        it('A_VENIR si elle n’est pas encore passée', async () => {
+        it('CLOTUREE si elle a une de date de clôture', async () => {
           // Given
           const maintenant = DateTime.local(2023)
           sessionRepository.getForConseiller.resolves(
-            success({ ...uneSessionMilo(), fin: maintenant.plus({ days: 1 }) })
+            success({
+              ...uneSessionMilo(),
+              dateCloture: maintenant.minus({ hours: 1 })
+            })
+          )
+
+          // When
+          const result = await getDetailSessionMiloQueryHandler.handle(query)
+
+          // Then
+          expect(isSuccess(result)).to.be.true()
+          if (isSuccess(result)) {
+            expect(result.data.session.statut).to.deep.equal(
+              SessionMilo.Statut.CLOTUREE
+            )
+          }
+        })
+
+        it('A_VENIR si elle n’est pas encore passée et qu’elle n’a pas de date de clôture', async () => {
+          // Given
+          const maintenant = DateTime.local(2023)
+          sessionRepository.getForConseiller.resolves(
+            success({
+              ...uneSessionMilo(),
+              fin: maintenant.plus({ days: 1 }),
+              dateCloture: undefined
+            })
           )
 
           // When
@@ -177,7 +203,7 @@ describe('GetDetailSessionConseillerMiloQueryHandler', () => {
           }
         })
 
-        it('A_CLOTURER si elle est passée mais qu’elle n’a pas de date de clôture', async () => {
+        it('A_CLOTURER si elle est passée et qu’elle n’a pas de date de clôture', async () => {
           // Given
           const maintenant = DateTime.local(2023)
           sessionRepository.getForConseiller.resolves(
@@ -196,29 +222,6 @@ describe('GetDetailSessionConseillerMiloQueryHandler', () => {
           if (isSuccess(result)) {
             expect(result.data.session.statut).to.deep.equal(
               SessionMilo.Statut.A_CLOTURER
-            )
-          }
-        })
-
-        it('CLOTUREE si elle est passée et qu’elle a une de date de clôture', async () => {
-          // Given
-          const maintenant = DateTime.local(2023)
-          sessionRepository.getForConseiller.resolves(
-            success({
-              ...uneSessionMilo(),
-              fin: maintenant.minus({ days: 1 }),
-              dateCloture: maintenant.minus({ hours: 1 })
-            })
-          )
-
-          // When
-          const result = await getDetailSessionMiloQueryHandler.handle(query)
-
-          // Then
-          expect(isSuccess(result)).to.be.true()
-          if (isSuccess(result)) {
-            expect(result.data.session.statut).to.deep.equal(
-              SessionMilo.Statut.CLOTUREE
             )
           }
         })

--- a/test/application/queries/milo/get-detail-session-conseiller.milo.query.handler.db.test.ts
+++ b/test/application/queries/milo/get-detail-session-conseiller.milo.query.handler.db.test.ts
@@ -4,7 +4,7 @@ import { createSandbox, SinonSandbox } from 'sinon'
 import { ConseillerAuthorizer } from 'src/application/authorizers/conseiller-authorizer'
 import { GetDetailSessionConseillerMiloQueryHandler } from 'src/application/queries/milo/get-detail-session-conseiller.milo.query.handler.db'
 import { ConseillerMiloSansStructure } from 'src/building-blocks/types/domain-error'
-import { failure, success } from 'src/building-blocks/types/result'
+import { failure, isSuccess, success } from 'src/building-blocks/types/result'
 import { ConseillerMilo } from 'src/domain/milo/conseiller.milo'
 import { KeycloakClient } from 'src/infrastructure/clients/keycloak-client'
 import { unUtilisateurConseiller } from 'test/fixtures/authentification.fixture'
@@ -15,7 +15,9 @@ import {
 } from 'test/fixtures/sessions.fixture'
 import { expect, StubbedClass, stubClass } from 'test/utils'
 import { getDatabase } from 'test/utils/database-for-testing'
-import { SessionMilo } from '../../../../src/domain/milo/session.milo'
+import { SessionMilo } from 'src/domain/milo/session.milo'
+import { DateService } from 'src/utils/date-service'
+import { DateTime } from 'luxon'
 
 describe('GetDetailSessionConseillerMiloQueryHandler', () => {
   let getDetailSessionMiloQueryHandler: GetDetailSessionConseillerMiloQueryHandler
@@ -23,6 +25,7 @@ describe('GetDetailSessionConseillerMiloQueryHandler', () => {
   let conseillerRepository: StubbedType<ConseillerMilo.Repository>
   let sessionRepository: StubbedType<SessionMilo.Repository>
   let conseillerAuthorizer: StubbedClass<ConseillerAuthorizer>
+  let dateService: StubbedClass<DateService>
   let sandbox: SinonSandbox
 
   before(() => {
@@ -36,12 +39,15 @@ describe('GetDetailSessionConseillerMiloQueryHandler', () => {
     conseillerRepository = stubInterface(sandbox)
     sessionRepository = stubInterface(sandbox)
     conseillerAuthorizer = stubClass(ConseillerAuthorizer)
+    dateService = stubClass(DateService)
+    dateService.now.returns(DateTime.local(2023))
     getDetailSessionMiloQueryHandler =
       new GetDetailSessionConseillerMiloQueryHandler(
         conseillerRepository,
         sessionRepository,
         conseillerAuthorizer,
-        keycloakClient
+        keycloakClient,
+        dateService
       )
   })
 
@@ -94,56 +100,129 @@ describe('GetDetailSessionConseillerMiloQueryHandler', () => {
       )
     })
 
-    it('récupère le détail d’une session', async () => {
-      // Given
+    describe('récupère le détail d’une session', () => {
       const tokenMilo = 'token-milo'
-      conseillerRepository.get
-        .withArgs(query.idConseiller)
-        .resolves(success(unConseillerMilo()))
-      keycloakClient.exchangeTokenConseillerMilo
-        .withArgs(query.token)
-        .resolves(tokenMilo)
-      sessionRepository.getForConseiller.resolves(success(uneSessionMilo()))
 
-      // When
-      const result = await getDetailSessionMiloQueryHandler.handle(query)
+      beforeEach(() => {
+        conseillerRepository.get
+          .withArgs(query.idConseiller)
+          .resolves(success(unConseillerMilo()))
+        keycloakClient.exchangeTokenConseillerMilo
+          .withArgs(query.token)
+          .resolves(tokenMilo)
+      })
 
-      // Then
-      expect(
-        sessionRepository.getForConseiller
-      ).to.have.been.calledOnceWithExactly(
-        query.idSession,
-        {
-          id: '1',
-          timezone: 'America/Cayenne'
-        },
-        tokenMilo
-      )
-      expect(result).to.deep.equal(
-        success({
-          ...unDetailSessionConseillerMiloQueryModel,
-          inscriptions: [
-            {
-              idJeune: 'id-hermione',
-              nom: 'Granger',
-              prenom: 'Hermione',
-              statut: SessionMilo.Inscription.Statut.INSCRIT
-            },
-            {
-              idJeune: 'id-ron',
-              nom: 'Weasley',
-              prenom: 'Ronald',
-              statut: SessionMilo.Inscription.Statut.REFUS_TIERS
-            },
-            {
-              idJeune: 'id-harry',
-              nom: 'Potter',
-              prenom: 'Harry',
-              statut: SessionMilo.Inscription.Statut.REFUS_JEUNE
-            }
-          ]
+      it('avec toutes ses informations', async () => {
+        // Given
+        sessionRepository.getForConseiller.resolves(success(uneSessionMilo()))
+
+        // When
+        const result = await getDetailSessionMiloQueryHandler.handle(query)
+
+        // Then
+        expect(
+          sessionRepository.getForConseiller
+        ).to.have.been.calledOnceWithExactly(
+          query.idSession,
+          {
+            id: '1',
+            timezone: 'America/Cayenne'
+          },
+          tokenMilo
+        )
+        expect(result).to.deep.equal(
+          success({
+            ...unDetailSessionConseillerMiloQueryModel,
+            inscriptions: [
+              {
+                idJeune: 'id-hermione',
+                nom: 'Granger',
+                prenom: 'Hermione',
+                statut: SessionMilo.Inscription.Statut.INSCRIT
+              },
+              {
+                idJeune: 'id-ron',
+                nom: 'Weasley',
+                prenom: 'Ronald',
+                statut: SessionMilo.Inscription.Statut.REFUS_TIERS
+              },
+              {
+                idJeune: 'id-harry',
+                nom: 'Potter',
+                prenom: 'Harry',
+                statut: SessionMilo.Inscription.Statut.REFUS_JEUNE
+              }
+            ]
+          })
+        )
+      })
+
+      describe('et lui affecte le statut ', () => {
+        it('A_VENIR si elle n’est pas encore passée', async () => {
+          // Given
+          const maintenant = DateTime.local(2023)
+          sessionRepository.getForConseiller.resolves(
+            success({ ...uneSessionMilo(), fin: maintenant.plus({ days: 1 }) })
+          )
+
+          // When
+          const result = await getDetailSessionMiloQueryHandler.handle(query)
+
+          // Then
+          expect(isSuccess(result)).to.be.true()
+          if (isSuccess(result)) {
+            expect(result.data.session.statut).to.deep.equal(
+              SessionMilo.Statut.A_VENIR
+            )
+          }
         })
-      )
+
+        it('A_CLOTURER si elle est passée mais qu’elle n’a pas de date de clôture', async () => {
+          // Given
+          const maintenant = DateTime.local(2023)
+          sessionRepository.getForConseiller.resolves(
+            success({
+              ...uneSessionMilo(),
+              fin: maintenant.minus({ days: 1 }),
+              dateCloture: undefined
+            })
+          )
+
+          // When
+          const result = await getDetailSessionMiloQueryHandler.handle(query)
+
+          // Then
+          expect(isSuccess(result)).to.be.true()
+          if (isSuccess(result)) {
+            expect(result.data.session.statut).to.deep.equal(
+              SessionMilo.Statut.A_CLOTURER
+            )
+          }
+        })
+
+        it('CLOTUREE si elle est passée et qu’elle a une de date de clôture', async () => {
+          // Given
+          const maintenant = DateTime.local(2023)
+          sessionRepository.getForConseiller.resolves(
+            success({
+              ...uneSessionMilo(),
+              fin: maintenant.minus({ days: 1 }),
+              dateCloture: maintenant.minus({ hours: 1 })
+            })
+          )
+
+          // When
+          const result = await getDetailSessionMiloQueryHandler.handle(query)
+
+          // Then
+          expect(isSuccess(result)).to.be.true()
+          if (isSuccess(result)) {
+            expect(result.data.session.statut).to.deep.equal(
+              SessionMilo.Statut.CLOTUREE
+            )
+          }
+        })
+      })
     })
   })
 })

--- a/test/domain/milo/session.milo.test.ts
+++ b/test/domain/milo/session.milo.test.ts
@@ -1,0 +1,61 @@
+import { SessionMilo } from 'src/domain/milo/session.milo'
+import { expect } from 'chai'
+import { DateTime } from 'luxon'
+
+describe('SessionMilo', () => {
+  describe('calculerStatut', () => {
+    const maintenant = DateTime.now()
+
+    describe('quand la date de fin est ultérieure à maintenant', () => {
+      it('retourne le statut A_VENIR', () => {
+        // Given
+        const dateFin = maintenant.plus({ days: 1 })
+        const dateCloture = undefined
+
+        // When
+        const statut = SessionMilo.calculerStatut(
+          maintenant,
+          dateFin,
+          dateCloture
+        )
+
+        // Then
+        expect(statut).to.equal(SessionMilo.Statut.A_VENIR)
+      })
+    })
+
+    describe('quand la date de fin est antérieure à maintenant', () => {
+      const dateFin = maintenant.minus({ days: 1 })
+
+      it('et que la date de clôture est absente, retourne  le statut A_CLOTURER', () => {
+        // Given
+        const dateCloture = undefined
+
+        // When
+        const statut = SessionMilo.calculerStatut(
+          maintenant,
+          dateFin,
+          dateCloture
+        )
+
+        // Then
+        expect(statut).to.equal(SessionMilo.Statut.A_CLOTURER)
+      })
+
+      it('et que la date de clôture est présente, retourne  le statut CLOTUREE', () => {
+        // Given
+        const dateCloture = maintenant.minus({ hours: 1 })
+
+        // When
+        const statut = SessionMilo.calculerStatut(
+          maintenant,
+          dateFin,
+          dateCloture
+        )
+
+        // Then
+        expect(statut).to.equal(SessionMilo.Statut.CLOTUREE)
+      })
+    })
+  })
+})

--- a/test/domain/milo/session.milo.test.ts
+++ b/test/domain/milo/session.milo.test.ts
@@ -6,44 +6,10 @@ describe('SessionMilo', () => {
   describe('calculerStatut', () => {
     const maintenant = DateTime.now()
 
-    describe('quand la date de fin est ultérieure à maintenant', () => {
-      it('retourne le statut A_VENIR', () => {
+    describe('quand la date de clôture est renseignée', () => {
+      it('retourne le statut CLOTUREE même si la date de fin est postérieure à maintenant', () => {
         // Given
         const dateFin = maintenant.plus({ days: 1 })
-        const dateCloture = undefined
-
-        // When
-        const statut = SessionMilo.calculerStatut(
-          maintenant,
-          dateFin,
-          dateCloture
-        )
-
-        // Then
-        expect(statut).to.equal(SessionMilo.Statut.A_VENIR)
-      })
-    })
-
-    describe('quand la date de fin est antérieure à maintenant', () => {
-      const dateFin = maintenant.minus({ days: 1 })
-
-      it('et que la date de clôture est absente, retourne  le statut A_CLOTURER', () => {
-        // Given
-        const dateCloture = undefined
-
-        // When
-        const statut = SessionMilo.calculerStatut(
-          maintenant,
-          dateFin,
-          dateCloture
-        )
-
-        // Then
-        expect(statut).to.equal(SessionMilo.Statut.A_CLOTURER)
-      })
-
-      it('et que la date de clôture est présente, retourne  le statut CLOTUREE', () => {
-        // Given
         const dateCloture = maintenant.minus({ hours: 1 })
 
         // When
@@ -55,6 +21,40 @@ describe('SessionMilo', () => {
 
         // Then
         expect(statut).to.equal(SessionMilo.Statut.CLOTUREE)
+      })
+    })
+
+    describe('quand la date de clôture n’est pas renseignée', () => {
+      const dateCloture = undefined
+
+      it('si la date de fin est ultérieure à maintenant, retourne  le statut A_VENIR', () => {
+        // Given
+        const dateFin = maintenant.plus({ days: 1 })
+
+        // When
+        const statut = SessionMilo.calculerStatut(
+          maintenant,
+          dateFin,
+          dateCloture
+        )
+
+        // Then
+        expect(statut).to.equal(SessionMilo.Statut.A_VENIR)
+      })
+
+      it('si la date de fin est antérieure à maintenant, retourne  le statut A_CLOTURER', () => {
+        // Given
+        const dateFin = maintenant.minus({ days: 1 })
+
+        // When
+        const statut = SessionMilo.calculerStatut(
+          maintenant,
+          dateFin,
+          dateCloture
+        )
+
+        // Then
+        expect(statut).to.equal(SessionMilo.Statut.A_CLOTURER)
       })
     })
   })

--- a/test/fixtures/sessions.fixture.ts
+++ b/test/fixtures/sessions.fixture.ts
@@ -19,7 +19,8 @@ export const uneSessionConseillerMiloQueryModel: SessionConseillerMiloQueryModel
     type: {
       code: OffreTypeCode.WORKSHOP,
       label: 'Atelier'
-    }
+    },
+    statut: SessionMilo.Statut.A_CLOTURER
   }
 
 export const uneSessionJeuneMiloQueryModel: SessionJeuneMiloQueryModel = {

--- a/test/fixtures/sessions.fixture.ts
+++ b/test/fixtures/sessions.fixture.ts
@@ -46,7 +46,8 @@ export const unDetailSessionConseillerMiloQueryModel: DetailSessionConseillerMil
       lieu: 'Un-lieu',
       estVisible: false,
       nbPlacesDisponibles: 10,
-      commentaire: 'Un-commentaire'
+      commentaire: 'Un-commentaire',
+      statut: SessionMilo.Statut.A_CLOTURER
     },
     offre: {
       id: '1',

--- a/test/infrastructure/routes/conseillers.milo.controller.test.ts
+++ b/test/infrastructure/routes/conseillers.milo.controller.test.ts
@@ -23,7 +23,7 @@ import {
   UpdateSessionMiloCommand,
   UpdateSessionMiloCommandHandler
 } from 'src/application/commands/milo/update-session-milo.command.handler'
-import { SessionMilo } from '../../../src/domain/milo/session.milo'
+import { SessionMilo } from 'src/domain/milo/session.milo'
 
 describe('ConseillersMiloController', () => {
   let getSessionsQueryHandler: StubbedClass<GetSessionsConseillerMiloQueryHandler>


### PR DESCRIPTION
- [x] Méthode pour calculer le statut
- [x] MAJ du getDetailSessionConselller avec le statut dans le DetailQueryModel
- [x] MAJ du getSessionsConselller avec le statut dans le SessionsQueryModel

⚠ Sonar renvoie un code smell sur le fait que `Statut` existe aussi pour les Inscription dans les SessionMilo. Perso, ça me gêne de remettre un nom lourd`StatutInscription` et `StatutSession` alors que l'on a déjà des namespaces… 
Mais encore une fois, je ne connais pas assez TS pour trancher : dites-moi :) 