### PR TITLE
fix: figer l'agence meme si la structure Milo change

### DIFF
--- a/src/infrastructure/repositories/milo/conseiller.milo.repository.db.ts
+++ b/src/infrastructure/repositories/milo/conseiller.milo.repository.db.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common'
-import { DateTime } from 'luxon'
 import {
   ConseillerMiloSansStructure,
   NonTrouveError
 } from '../../../building-blocks/types/domain-error'
 import { Result, failure, success } from '../../../building-blocks/types/result'
 import { Conseiller } from '../../../domain/milo/conseiller'
+import { ConseillerMiloModifie } from '../../../domain/milo/conseiller.milo.db'
 import { ConseillerSqlModel } from '../../sequelize/models/conseiller.sql-model'
 import { StructureMiloSqlModel } from '../../sequelize/models/structure-milo.sql-model'
 
@@ -34,12 +34,7 @@ export class ConseillerMiloSqlRepository implements Conseiller.Milo.Repository {
     })
   }
 
-  async save(conseiller: {
-    id: string
-    idAgence?: string | null
-    idStructure?: string | null
-    dateVerificationStructureMilo: DateTime
-  }): Promise<void> {
+  async save(conseiller: ConseillerMiloModifie): Promise<void> {
     await ConseillerSqlModel.update(
       {
         idAgence: conseiller.idAgence,


### PR DESCRIPTION
On voulait que le référentiel des agences suive celui des structures Milo
Le problème c'est que si ça bouge, on doit savoir si c'est un déménagement, fusion d'agences, absorption ou disparition d'agance afin de gérer le transfert des données rattachées (animations collectives).
Aujourd'hui on en sait rien.
Donc on va laisser les Agences figées, comme c'est le cas aujourd'hui.
La seule amélioration apportée par ce code c'est qu'on n'aura plus besoin de modale de selection d'agence.
La PR front pour supprimer la modale va suivre